### PR TITLE
Update setup.py, exclude tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     long_description=long_description,
     url='https://github.com/ChrisMandich/PyFlume',
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=['tests','tests.*']),
     classifiers=[
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
otherwise it would try to install a package called 'tests' at top level:
```
root@g18-hasstest:/usr/portage/homeassistant/dev-python/PyFlume # emerge -1tv PyFlume

Local copy of remote index is up-to-date and will be used.

 * IMPORTANT: 16 news items need reading for repository 'gentoo'.
 * Use eselect news read to view new items.


Local copy of remote index is up-to-date and will be used.

These are the packages that would be merged, in reverse order:

Calculating dependencies... done!
[ebuild  N    ~] dev-python/PyFlume-0.6.5::HomeAssistantRepository  USE="test" PYTHON_TARGETS="python3_9 -python3_8 -python3_10" 0 KiB
[ebuild  N    ~]  dev-python/ratelimit-2.2.1::HomeAssistantRepository  USE="test" PYTHON_TARGETS="python3_9 -python3_8 -python3_10" 13 KiB

Total: 2 packages (2 new), Size of downloads: 13 KiB

>>> Verifying ebuild manifests
>>> Emerging (1 of 2) dev-python/ratelimit-2.2.1::HomeAssistantRepository
>>> Installing (1 of 2) dev-python/ratelimit-2.2.1::HomeAssistantRepository
>>> Emerging (2 of 2) dev-python/PyFlume-0.6.5::HomeAssistantRepository
>>> Failed to emerge dev-python/PyFlume-0.6.5, Log file:
>>>  '/var/tmp/portage/dev-python/PyFlume-0.6.5/temp/build.log'
>>> Jobs: 1 of 2 complete, 1 failed                 Load avg: 0.14, 0.03, 0.05
 * Package:    dev-python/PyFlume-0.6.5
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   Chris@Mandich.net
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_9 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking PyFlume-0.6.5.tar.gz to /var/tmp/portage/dev-python/PyFlume-0.6.5/work
>>> Source unpacked in /var/tmp/portage/dev-python/PyFlume-0.6.5/work
>>> Preparing source in /var/tmp/portage/dev-python/PyFlume-0.6.5/work/PyFlume-0.6.5 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/PyFlume-0.6.5/work/PyFlume-0.6.5 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/PyFlume-0.6.5/work/PyFlume-0.6.5 ...
 * python3_9: running distutils-r1_run_phase distutils-r1_python_compile
python3.9 setup.py build -j 6
running build
running build_py
creating /var/tmp/portage/dev-python/PyFlume-0.6.5/work/PyFlume-0.6.5-python3_9/lib/pyflume
copying pyflume/__init__.py -> /var/tmp/portage/dev-python/PyFlume-0.6.5/work/PyFlume-0.6.5-python3_9/lib/pyflume
copying pyflume/format_time.py -> /var/tmp/portage/dev-python/PyFlume-0.6.5/work/PyFlume-0.6.5-python3_9/lib/pyflume
creating /var/tmp/portage/dev-python/PyFlume-0.6.5/work/PyFlume-0.6.5-python3_9/lib/tests
copying tests/__init__.py -> /var/tmp/portage/dev-python/PyFlume-0.6.5/work/PyFlume-0.6.5-python3_9/lib/tests
copying tests/test_init.py -> /var/tmp/portage/dev-python/PyFlume-0.6.5/work/PyFlume-0.6.5-python3_9/lib/tests
warning: build_py: byte-compiling is disabled, skipping.

>>> Source compiled.
>>> Test phase [not enabled]: dev-python/PyFlume-0.6.5

>>> Install dev-python/PyFlume-0.6.5 into /var/tmp/portage/dev-python/PyFlume-0.6.5/image
 * python3_9: running distutils-r1_run_phase distutils-r1_python_install
python3.9 setup.py install --skip-build --root=/var/tmp/portage/dev-python/PyFlume-0.6.5/image/_python3.9
running install
running install_lib
creating /var/tmp/portage/dev-python/PyFlume-0.6.5/image/_python3.9
creating /var/tmp/portage/dev-python/PyFlume-0.6.5/image/_python3.9/usr
creating /var/tmp/portage/dev-python/PyFlume-0.6.5/image/_python3.9/usr/lib
creating /var/tmp/portage/dev-python/PyFlume-0.6.5/image/_python3.9/usr/lib/python3.9
creating /var/tmp/portage/dev-python/PyFlume-0.6.5/image/_python3.9/usr/lib/python3.9/site-packages
creating /var/tmp/portage/dev-python/PyFlume-0.6.5/image/_python3.9/usr/lib/python3.9/site-packages/pyflume
copying /var/tmp/portage/dev-python/PyFlume-0.6.5/work/PyFlume-0.6.5-python3_9/lib/pyflume/__init__.py -> /var/tmp/portage/dev-python/PyFlume-0.6.5/image/_python3.9/usr/lib/python3.9/site-packages/pyflume
copying /var/tmp/portage/dev-python/PyFlume-0.6.5/work/PyFlume-0.6.5-python3_9/lib/pyflume/format_time.py -> /var/tmp/portage/dev-python/PyFlume-0.6.5/image/_python3.9/usr/lib/python3.9/site-packages/pyflume
creating /var/tmp/portage/dev-python/PyFlume-0.6.5/image/_python3.9/usr/lib/python3.9/site-packages/tests
copying /var/tmp/portage/dev-python/PyFlume-0.6.5/work/PyFlume-0.6.5-python3_9/lib/tests/__init__.py -> /var/tmp/portage/dev-python/PyFlume-0.6.5/image/_python3.9/usr/lib/python3.9/site-packages/tests
copying /var/tmp/portage/dev-python/PyFlume-0.6.5/work/PyFlume-0.6.5-python3_9/lib/tests/test_init.py -> /var/tmp/portage/dev-python/PyFlume-0.6.5/image/_python3.9/usr/lib/python3.9/site-packages/tests
byte-compiling /var/tmp/portage/dev-python/PyFlume-0.6.5/image/_python3.9/usr/lib/python3.9/site-packages/pyflume/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/PyFlume-0.6.5/image/_python3.9/usr/lib/python3.9/site-packages/pyflume/format_time.py to format_time.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/PyFlume-0.6.5/image/_python3.9/usr/lib/python3.9/site-packages/tests/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/PyFlume-0.6.5/image/_python3.9/usr/lib/python3.9/site-packages/tests/test_init.py to test_init.cpython-39.pyc
writing byte-compilation script '/var/tmp/portage/dev-python/PyFlume-0.6.5/temp/tmpuyfsa_l7.py'
/usr/bin/python3.9 /var/tmp/portage/dev-python/PyFlume-0.6.5/temp/tmpuyfsa_l7.py
removing /var/tmp/portage/dev-python/PyFlume-0.6.5/temp/tmpuyfsa_l7.py
writing byte-compilation script '/var/tmp/portage/dev-python/PyFlume-0.6.5/temp/tmpufibjkeq.py'
/usr/bin/python3.9 /var/tmp/portage/dev-python/PyFlume-0.6.5/temp/tmpufibjkeq.py
removing /var/tmp/portage/dev-python/PyFlume-0.6.5/temp/tmpufibjkeq.py
running install_egg_info
running egg_info
writing PyFlume.egg-info/PKG-INFO
writing dependency_links to PyFlume.egg-info/dependency_links.txt
writing requirements to PyFlume.egg-info/requires.txt
writing top-level names to PyFlume.egg-info/top_level.txt
reading manifest file 'PyFlume.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'PyFlume.egg-info/SOURCES.txt'
Copying PyFlume.egg-info to /var/tmp/portage/dev-python/PyFlume-0.6.5/image/_python3.9/usr/lib/python3.9/site-packages/PyFlume-0.6.5-py3.9.egg-info
running install_scripts
 * ERROR: dev-python/PyFlume-0.6.5::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system.
 *
 * Call stack:
 *     ebuild.sh, line  127:  Called src_install
 *   environment, line 2873:  Called distutils-r1_src_install
 *   environment, line 1193:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_install'
 *   environment, line  455:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2543:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2073:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2071:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line  775:  Called distutils-r1_run_phase 'distutils-r1_python_install'
 *   environment, line 1161:  Called distutils-r1_python_install
 *   environment, line 1063:  Called die
 * The specific snippet of code:
 *               die "Package installs '${p}' package which is forbidden and likely a bug in the build system.";
 *
```